### PR TITLE
Adding reset of authentication after failing with 401 return code

### DIFF
--- a/z-way.coffee
+++ b/z-way.coffee
@@ -86,7 +86,6 @@ module.exports = (env) ->
         return commandAnswer
       .catch (error)=>
         if error.message.match(401)
-          #looks like authentication failed
           env.logger.error ("reseting authentication")
           @authenticated = false
 
@@ -109,7 +108,6 @@ module.exports = (env) ->
         return deviceDetails
       .catch (error)=>
         if error.message.match(401)
-          #looks like authentication failed
           env.logger.error ("reseting authentication")
           @authenticated = false
 

--- a/z-way.coffee
+++ b/z-way.coffee
@@ -84,6 +84,11 @@ module.exports = (env) ->
           return json
 
         return commandAnswer
+      .catch (error)=>
+        if error.message.match(401)
+          #looks like authentication failed
+          env.logger.error ("reseting authentication")
+          @authenticated = false
 
     getDeviceDetails: (virtualDeviceId) ->
       address = "http://" + @config.hostname + ":8083/ZAutomation/api/v1/devices/" + virtualDeviceId
@@ -102,6 +107,13 @@ module.exports = (env) ->
           return json
 
         return deviceDetails
+      .catch (error)=>
+        if error.message.match(401)
+          #looks like authentication failed
+          env.logger.error ("reseting authentication")
+          @authenticated = false
+
+
 
     logIn: ()->
       if @authenticated then return Promise.resolve()


### PR DESCRIPTION
Currently if the zway server restarts or the session is closed for some other reason the plugin still thinks it is authenticated and doesn't reauthenticate. This fixes this behaviour and triggers a reauthentication on the next try.
